### PR TITLE
Fix DNS detection

### DIFF
--- a/tasks/check-and-update.yml
+++ b/tasks/check-and-update.yml
@@ -10,7 +10,7 @@
 
 - name: Fail when no DNS entry is set
   fail: msg="DNS entry was not set in the Sophos Firewall / DNS-Server"
-  when: dig_result.stdout | length > 0
+  when: dig_result.stdout | length == 0
   check_mode: false
 
 - name: Regenerate ssh host keys


### PR DESCRIPTION
Fixes a regression of commit 674b35f7f369, which changed the code to
fix an ansible-lint issue with:

|  -  when: dig_result.stdout == ""
|  +  when: dig_result.stdout | length > 0

While this logic would work only for:

|  -  when: dig_result.stdout != ""