### PR TITLE
check-and-update: ensure to delete ssh host keys to actually re-generate them

### DIFF
--- a/tasks/check-and-update.yml
+++ b/tasks/check-and-update.yml
@@ -13,6 +13,13 @@
   when: dig_result.stdout | length > 0
   check_mode: false
 
+- name: Delete ssh host keys
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_fileglob:
+    - "/etc/ssh/ssh_host*"
+
 - name: Regenerate ssh host keys
   command: dpkg-reconfigure openssh-server
   when: template_vm|bool


### PR DESCRIPTION
`dpkg-reconfigure openssh-server` regenerates the SSH host keys
iff they don't exist yet. We need to remove the SSH host key
files before therefore.